### PR TITLE
Fix Trino MinIO S3 configuration

### DIFF
--- a/lakehouse/etc/catalog/hive.properties
+++ b/lakehouse/etc/catalog/hive.properties
@@ -3,8 +3,8 @@ hive.metastore.uri=thrift://hive-metastore:9083
 hive.non-managed-table-writes-enabled=true
 
 fs.native-s3.enabled=true
-s3.path-style-access=true
-s3.region=us-east-1
-s3.endpoint=http://s3gateway:9000
-s3.aws-access-key=admin
-s3.aws-secret-key=adminadmin123
+hive.s3.path-style-access=true
+hive.s3.region=us-east-1
+hive.s3.endpoint=http://minio:9000
+hive.s3.aws-access-key=admin
+hive.s3.aws-secret-key=adminadmin123


### PR DESCRIPTION
## Summary
- point the Trino Hive catalog to the MinIO service using the correct endpoint host
- switch the S3 configuration keys to the hive.s3.* names so the connector picks up the credentials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3af314ee48322909754ee12c0e820